### PR TITLE
Prevents a scary divide by zero situation 

### DIFF
--- a/UI/ScanRegionUI.cs
+++ b/UI/ScanRegionUI.cs
@@ -433,8 +433,8 @@ namespace LiveSplit.VAS.UI
             if (_ActivePreviewType == PreviewType.FullFrame)
             {
                 var vGeo = _VideoGeometry;
-                var widthMultiplier = (decimal)vGeo.Width / pictureBox.Width;
-                var heightMultiplier = (decimal)vGeo.Height / pictureBox.Height;
+                var widthMultiplier = pictureBox.Width <= 0 ? 1 : (decimal)vGeo.Width / pictureBox.Width;
+                var heightMultiplier = pictureBox.Height <= 0 ? 1 : (decimal)vGeo.Height / pictureBox.Height;
                 numX.Value = _SelectionStart.X * widthMultiplier;
                 numY.Value = _SelectionStart.Y * heightMultiplier;
                 numWidth.Value = 0m;

--- a/UI/ScanRegionUI.cs
+++ b/UI/ScanRegionUI.cs
@@ -466,8 +466,8 @@ namespace LiveSplit.VAS.UI
             var vGeo = _VideoGeometry;
             decimal screenWidth = (decimal)vGeo.Width;
             decimal screenHeight = (decimal)vGeo.Height;
-            decimal widthMultiplier = screenWidth / pictureBox.Width;
-            decimal heightMultiplier = screenHeight / pictureBox.Height;
+            decimal widthMultiplier =   pictureBox.Width <= 0 ? 1 : screenWidth / pictureBox.Width;
+            decimal heightMultiplier = pictureBox.Height <= 0 ? 1 : screenHeight / pictureBox.Height;
 
             int mouseX = Math.Min(Math.Max(0, newPoint.X), (int)Math.Round(screenWidth / widthMultiplier));
             int mouseY = Math.Min(Math.Max(0, newPoint.Y), (int)Math.Round(screenHeight / heightMultiplier));


### PR DESCRIPTION
This should prevent us from performing in this one method a divide by zero as forcing this to be a `1` when it cannot do a division means all additional logic will be able to run without error. 

