### PR TITLE
Fix features not showing sometimes

### DIFF
--- a/UI/FeaturesUI.cs
+++ b/UI/FeaturesUI.cs
@@ -224,7 +224,10 @@ namespace LiveSplit.VAS.UI
 
             if (double.IsNaN(numValue))
             {
-                textBlock.Value = value.ToString();
+                if (value != null)
+                {
+                    textBlock.Value = value.ToString();
+                }
             }
             else
             {


### PR DESCRIPTION
When the feature value is null, `null.ToString()` was causing an exception meaning the features tab would be completely blank. This fixes it by leaving the textblock at the default value of "Unset".