### PR TITLE
Fix error logging only working when running as administrator

### DIFF
--- a/Log.cs
+++ b/Log.cs
@@ -23,16 +23,15 @@ namespace LiveSplit.VAS
             {
                 if (!EventLog.SourceExists("VideoAutoSplit"))
                     EventLog.CreateEventSource("VideoAutoSplit", "Application");
-            }
-            catch { }
 
-            try
-            {
                 var listener = new EventLogTraceListener("VideoAutoSplit");
                 listener.Filter = new EventTypeFilter(SourceLevels.Warning);
                 Trace.Listeners.Add(listener);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Trace.TraceError(ex.ToString());
+            }
         }
 
         public static string ReadAll() => _TextWriter.ToString();


### PR DESCRIPTION
When LiveSplit does not have access to create or read Event Logs, `EventLog.SourceExists` will throw an exception.
So what was happening was that the creation of the event source failed, but the trace listener was still added.
Then, every time a trace was made it would throw an exception because it didn't have access to the event log.
This works when running as administrator, but fails otherwise.